### PR TITLE
Improve view transitions between home and player views

### DIFF
--- a/TruexGoogleReferenceApp/Base.lproj/Main.storyboard
+++ b/TruexGoogleReferenceApp/Base.lproj/Main.storyboard
@@ -24,9 +24,14 @@
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="wu6-TO-1qx"/>
                     </view>
+                    <connections>
+                        <segue destination="su3-o3-bqJ" kind="unwind" identifier="ReturnToStreamSelect" unwindAction="unwindToHomeWithSegue:" id="kBe-Aq-S92"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                <exit id="su3-o3-bqJ" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
+            <point key="canvasLocation" x="18" y="69"/>
         </scene>
         <!--HomeViewController-->
         <scene sceneID="WqV-3B-o8o">
@@ -71,7 +76,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </view>
                                         <connections>
-                                            <segue destination="BYZ-38-t0r" kind="show" animates="NO" id="uKz-Dv-rsI"/>
+                                            <segue destination="BYZ-38-t0r" kind="presentation" animates="NO" id="uKz-Dv-rsI"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -95,7 +100,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <segue destination="BYZ-38-t0r" kind="show" animates="NO" id="tbk-s1-TdP"/>
+                                    <segue destination="BYZ-38-t0r" kind="presentation" animates="NO" id="tbk-s1-TdP"/>
                                 </connections>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="PlayButton" translatesAutoresizingMaskIntoConstraints="NO" id="M6q-8d-lwJ">
@@ -113,6 +118,7 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="fEh-M0-7bc"/>
                     </view>
+                    <navigationItem key="navigationItem" id="3M9-Hq-b0q"/>
                     <connections>
                         <outlet property="collectionView" destination="zsC-aa-iFY" id="KCr-DF-Xun"/>
                         <outlet property="streamDescription" destination="xgo-cm-Ggi" id="yOH-hg-XGL"/>
@@ -129,6 +135,6 @@
         <image name="PlayButton" width="51" height="51"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="tbk-s1-TdP"/>
+        <segue reference="uKz-Dv-rsI"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/TruexGoogleReferenceApp/HomeViewController.swift
+++ b/TruexGoogleReferenceApp/HomeViewController.swift
@@ -61,6 +61,7 @@ class HomeViewController: UIViewController,
             playerViewController.setStream(contentSourceID: focusedStream.googleContentID,
                                            videoID: focusedStream.googleVideoID)
             setScreenshotAsLoadingScreen(for: playerViewController)
+            playerLayer?.player?.pause()
         }
     }
  
@@ -116,6 +117,8 @@ class HomeViewController: UIViewController,
         setupLoopingPreview(videoURLString: configuration.preview)
     }
     
+    @IBAction func unwindToHome(segue: UIStoryboardSegue) {}
+    
     private func indexOfSelectedStream() -> Int {
         if let streamConfigurations = streamConfigurations, let focusedStream = focusedStream {
             return streamConfigurations.firstIndex(where: { $0 == focusedStream }) ?? 0
@@ -131,6 +134,7 @@ class HomeViewController: UIViewController,
             playerLooper = AVPlayerLooper(player: player,
                                           templateItem: playerItem)
             playerLayer?.player = player
+            player.volume = 0
             player.play()
         }
     }

--- a/TruexGoogleReferenceApp/PlayerViewController.swift
+++ b/TruexGoogleReferenceApp/PlayerViewController.swift
@@ -207,11 +207,12 @@ class PlayerViewController: UIViewController,
     
     // This is invoked when the user presses the menu button on the TV remote while the renderer is still showing the
     // engagement choice card. In that case, we assume the user wants to cancel the whole stream, not just the true[X]
-    // experience, so we dismiss the view controller, exiting the app. Of course, in a real media app, this would instead
-    // go back to the episode list view, or whatever is appropriate.
+    // experience. We dismiss the view controller, returning to the stream selection screen
     func onUserCancelStream() {
         // [8]
-        dismiss(animated: true)
+        playerViewController.dismiss(animated: false, completion: {
+            self.performSegue(withIdentifier: "ReturnToStreamSelect", sender: self)
+        })
     }
     
     // Finally, this method is invoked after the renderer has finished initialization, and since we always initialize the
@@ -252,6 +253,10 @@ class PlayerViewController: UIViewController,
             }
         }
         return adBreakStartTime
+    }
+    
+    func playerViewControllerDidEndDismissalTransition(_ playerViewController: AVPlayerViewController) {
+        performSegue(withIdentifier: "ReturnToStreamSelect", sender: self)
     }
     
     // MARK: - NS Object Overrides


### PR DESCRIPTION
Mute the audio on the home screen preview. Also pause the
home screen preview video when we transition to the player.

Correct the behavior of pressing the "MENU" button in the
stream to exit back to the home screen on a single press.

Fix behavior of the "MENU" button for the user cancel
stream event.