### PR TITLE
Change Innovid spec repo link to match reference

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ platform :tvos, '10.0'
 
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/socialvibe/cocoapod-specs.git'
-source 'https://innovid-cocoapods:3bbe7445d58951a8f89c5e54c0ebfdd17039589e@github.com/Innovid/cocoapods-spec.git'
+source 'https://github.com/Innovid/cocoapods-spec.git'
 source 'https://github.com/YOU-i-Labs/YouiTVAdRenderer-CocoaPod.git'
 
 target 'TruexGoogleReferenceApp' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -94,12 +94,12 @@ SPEC REPOS:
     - Starscream
     - SWXMLHash
     - TaskQueue
+  https://github.com/Innovid/cocoapods-spec.git:
+    - InnovidAdRenderer
   https://github.com/socialvibe/cocoapod-specs.git:
     - TruexAdRenderer
   https://github.com/YOU-i-Labs/YouiTVAdRenderer-CocoaPod.git:
     - YouiTVAdRenderer
-  "https://innovid-cocoapods:3bbe7445d58951a8f89c5e54c0ebfdd17039589e@github.com/Innovid/cocoapods-spec.git":
-    - InnovidAdRenderer
 
 EXTERNAL SOURCES:
   IMA:
@@ -129,6 +129,6 @@ SPEC CHECKSUMS:
   TruexAdRenderer: 0e71707e172d0273f363eb2806b28f45970a3873
   YouiTVAdRenderer: cce73614e764d16fe4dc4b1954d64fc789507231
 
-PODFILE CHECKSUM: ed2f895ebc415a19159df5724f63c5b3ab2d1574
+PODFILE CHECKSUM: 5d46ba659e4a4794ac90859791cabca7ab660cad
 
 COCOAPODS: 1.5.3

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ ad renderer with the Google Ad Manager IMA SDK in tvOS. This document will step 
 various pieces of code that make the integration work, so that the same basic ideas can
 be replicated in a real production app.
 
+This reference app covers the essential work. For a more detailed integration guide, please refer to: https://github.com/socialvibe/truex-tvos-integrations.
+
 # Assumptions
 
 We assume you have either already integrated the IMA SDK with your app, or you are


### PR DESCRIPTION
Innovid's spec repo is public so the extra info the URL is
not needed. Updated it to match their documentation:
https://github.com/Innovid/tvos-framework-live-demo

Added a link to the full tvOS integration doc