### PR TITLE
Show ad cuepoints in AVPlayer UI

### DIFF
--- a/TruexGoogleReferenceApp/Info.plist
+++ b/TruexGoogleReferenceApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
AVPlayer allows the cuepoints for ads
to be specified within each AVPlayerItem.
We receive these from the Google IMA SDK
and set them when the stream is ready
to play.

![image](https://user-images.githubusercontent.com/5824989/55843217-f5d98b00-5aeb-11e9-9fd6-951efef31517.png)
