### PR TITLE
Pause renderer on background

### DIFF
--- a/TruexGoogleReferenceApp.xcodeproj/project.pbxproj
+++ b/TruexGoogleReferenceApp.xcodeproj/project.pbxproj
@@ -129,6 +129,11 @@
 				TargetAttributes = {
 					4039DD012227587F003FF448 = {
 						CreatedOnToolsVersion = 10.1;
+						SystemCapabilities = {
+							com.apple.BackgroundModes.appletvos = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};

--- a/TruexGoogleReferenceApp/Info.plist
+++ b/TruexGoogleReferenceApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
@@ -27,6 +27,10 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/TruexGoogleReferenceApp/PlayerViewController.swift
+++ b/TruexGoogleReferenceApp/PlayerViewController.swift
@@ -69,12 +69,12 @@ class PlayerViewController: UIViewController,
     
     private func listenForApplicationEvents() {
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(self.applicationDidEnterBackground),
-                                               name: UIApplication.didEnterBackgroundNotification,
+                                               selector: #selector(self.willResignActiveNotification),
+                                               name: UIApplication.willResignActiveNotification,
                                                object: nil)
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(self.applicationWillEnterForeground),
-                                               name: UIApplication.willEnterForegroundNotification,
+                                               selector: #selector(self.didBecomeActiveNotification),
+                                               name: UIApplication.didBecomeActiveNotification,
                                                object: nil)
     }
 
@@ -93,11 +93,11 @@ class PlayerViewController: UIViewController,
     
     // MARK: - UIApplicationDelegate Methods
     // MARK: [REQUIRED]
-    @objc func applicationDidEnterBackground(_ application: UIApplication) {
+    @objc func willResignActiveNotification(_ application: UIApplication) {
         adRenderer?.pause()
     }
 
-    @objc func applicationWillEnterForeground(_ application: UIApplication) {
+    @objc func didBecomeActiveNotification(_ application: UIApplication) {
         adRenderer?.resume()
     }
 

--- a/TruexGoogleReferenceApp/PlayerViewController.swift
+++ b/TruexGoogleReferenceApp/PlayerViewController.swift
@@ -63,9 +63,21 @@ class PlayerViewController: UIViewController,
         streamManager.delegate = self
         playerViewController.delegate = self
 
+        listenForApplicationEvents()
         /* [OPTIONAL] */ listenForPlayerStatus()
     }
     
+    private func listenForApplicationEvents() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(self.applicationDidEnterBackground),
+                                               name: UIApplication.didEnterBackgroundNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(self.applicationWillEnterForeground),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -79,6 +91,16 @@ class PlayerViewController: UIViewController,
         present(playerViewController, animated: false)
     }
     
+    // MARK: - UIApplicationDelegate Methods
+    // MARK: [REQUIRED]
+    @objc func applicationDidEnterBackground(_ application: UIApplication) {
+        adRenderer?.pause()
+    }
+
+    @objc func applicationWillEnterForeground(_ application: UIApplication) {
+        adRenderer?.resume()
+    }
+
     // MARK: - IMA Stream Manager Delegate Methods
     // MARK: [REQUIRED]
     func streamManager(_ streamManager: IMAStreamManager?, adBreakDidStart adBreakInfo: IMAAdBreakInfo?) {
@@ -195,16 +217,19 @@ class PlayerViewController: UIViewController,
     // If there the true[X] renderer did not receive an ad, we record the time range of the placeholder ad to skip over it if needed
     func onAdCompleted(_ timeSpent: Int) {
         // [7]
+        adRenderer = nil
         player.play()
     }
     
     func onAdError(_ errorMessage: String?) {
         // [7]
+        adRenderer = nil
         seekAfterTrueXInvalidAndPlay()
     }
     
     func onNoAdsAvailable() {
         // [7]
+        adRenderer = nil
         seekAfterTrueXInvalidAndPlay()
     }
     


### PR DESCRIPTION
Pausing the renderer when the app is
backgrounded ensures the timing logic
for choice cards and creatives functions
correctly.

Nil out ad renderer after terminal events
to ensure we're not calling `pause` and 
`resume` on a no longer active renderer.